### PR TITLE
fix css warnings in alert.html

### DIFF
--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/views/fragments/alert.html
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/views/fragments/alert.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <link href="../../../resources/css/bootstrap.min.css" rel="stylesheet" media="screen" th:href="@{/resources/css/bootstrap.min.css}"/>
+</head>
 <body>
     <div th:fragment="alert (type, message)" class="alert alert-dismissable" th:classappend="'alert-' + ${type}">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
@@ -7,4 +10,3 @@
     </div>
 </body>
 </html>
-


### PR DESCRIPTION
Insert bootstrap.min.css stylesheet link in order to resolve CSS warnings.