### PR TITLE
Fix resources-plugin to remove useless trace

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -206,7 +206,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.7</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>


### PR DESCRIPTION
Because you are still using version 2.5 of the maven-resources-plugin, we are getting those useless traces: [INFO] [debug] execute contextualize

By moving to the last version, the message disappears.
