### PR TITLE
Clarification for new project creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ To install the archetype in your local repository execute following commands:
 Create a project
 ----------------
 
+Create a new empty directory for your project and navigate into it.
+
 ```bash
     mvn archetype:generate \
         -DarchetypeGroupId=com.github.spring-mvc-archetypes \


### PR DESCRIPTION
While following the documentation, if you attempt to run the 'mvn archetype:generate...' command while in the archetype folder you will receive an error like the following: Unable to add module to the current project as it is not of packaging type 'pom'.

Clarification added for developers who are following the documentation on autopilot.