### PR TITLE
switch to BCryptPasswordEncoder from StandardPasswordEncoder

### DIFF
--- a/src/main/resources/archetype-resources/src/main/java/config/SecurityConfig.java
+++ b/src/main/resources/archetype-resources/src/main/java/config/SecurityConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.crypto.password.StandardPasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices;
 
 import ${package}.account.AccountService;
@@ -31,8 +31,8 @@ class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new StandardPasswordEncoder();
-	}
+        return new BCryptPasswordEncoder();
+    }
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {


### PR DESCRIPTION
BCryptPasswordEncoder is superior to StandardPasswordEncoder. Stronger security and is standardized so it's compatible with other apps using different languages and frameworks.

See:
http://stackoverflow.com/questions/17444258/how-to-use-new-passwordencoder-from-spring-security

And this comment at the top of the StandardPasswordEncoder.java file:
>   If you are developing a new system,
>   {@link org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder} is a better
>   choice both in terms of security and interoperability with other languages.